### PR TITLE
App config typo on Nova installation

### DIFF
--- a/nova/1.0/getting-started/installation.md
+++ b/nova/1.0/getting-started/installation.md
@@ -19,7 +19,7 @@ composer require maatwebsite/laravel-nova-excel
 
 ## Service Provider
 
-In case you don't have auto-discovery enabled, you'll have to add the following two service providers in `app/config.php`
+In case you don't have auto-discovery enabled, you'll have to add the following two service providers in `config/app.php`
 
 ```
 'providers' => [


### PR DESCRIPTION
Just a small typo; corrected `app/config.php`. Thanks for building such a useful package!