### PR TITLE
Fix ToCollection example

### DIFF
--- a/3.1/imports/collection.md
+++ b/3.1/imports/collection.md
@@ -19,14 +19,15 @@ use Maatwebsite\Excel\Concerns\ToCollection;
 
 class UsersImport implements ToCollection
 {
-    public function collection(Collection $rows)
+    public $data;
+
+    public function collection(Collection $collection)
     {
-        foreach ($rows as $row) 
-        {
-            User::create([
+        $this->data = $collection->transform(function ($row) {
+            return User::make([
                 'name' => $row[0],
             ]);
-        }
+        });
     }
 }
 ```
@@ -40,7 +41,9 @@ In your controller we can now import this:
 ```php
 public function import() 
 {
-    Excel::import(new UsersImport, 'users.xlsx');
+    $import = new UsersImport;
+    Excel::import($import, 'users.xlsx');
+    $resultsCollection = $import->data;
 }
 ```
 


### PR DESCRIPTION
As revealed in #1980 and #1999 if any parsing/processing of records is desired when using ToCollection, it must be done via model properties, because all of the results of the `collection(Collection $row)` call are ignored otherwise.

The previous example with a foreach loop never did anything with the data, so the loop was pointless.