### PR TITLE
Add send() call after download()

### DIFF
--- a/3.1/exports/exportables.md
+++ b/3.1/exports/exportables.md
@@ -27,13 +27,13 @@ class InvoicesExport implements FromCollection
 We can now download the export without the need for the facade:
 
 ```php
-return (new InvoicesExport)->download('invoices.xlsx');
+return (new InvoicesExport)->download('invoices.xlsx')->send();
 ```
 
 You can also pass the Writer Type and optional headers to the download method:
 
 ```php
-return (new InvoicesExport)->download('invoices.csv', Excel::CSV, ['Content-Type' => 'text/csv']);
+return (new InvoicesExport)->download('invoices.csv', Excel::CSV, ['Content-Type' => 'text/csv'])->send();
 ```
 
 Or store it on a disk:


### PR DESCRIPTION
For some reason, using `download()` by itself does not actually download the file (but upon `var_dump` checks, it generates the necessary headers, it just isn't sending it over to the client to start the download).

Adding `send()` like in the examples I modified above worked for me. I haven't tested this on non-exportables (like via the Facade), but I assume it will also apply.