### PR TITLE
Update column-formatting.md

### DIFF
--- a/3.1/exports/column-formatting.md
+++ b/3.1/exports/column-formatting.md
@@ -24,9 +24,6 @@ class InvoicesExport implements WithColumnFormatting, WithMapping
         ];
     }
     
-    /**
-     * @return array
-     */
     public function columnFormats(): array
     {
         return [


### PR DESCRIPTION
Remove Docblock from `columnFormats` as Docblocks aren't used in the code examples.