### PR TITLE
Adding documentation about custom formatting when importing

### DIFF
--- a/3.1/imports/custom-formatting-values.md
+++ b/3.1/imports/custom-formatting-values.md
@@ -7,7 +7,7 @@
 By default Laravel Excel uses PhpSpreadsheet's default value binder to intelligently format a cell's value when reading it. You may override this behavior by implementing the `WithCustomValueBinder` concern and the `bindValue` method. Your import class may also extend `DefaultValueBinder` to return the default behavior.
 
 ```php
-namespace App\Exports;
+namespace App\Imports;
 
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use Maatwebsite\Excel\Concerns\ToModel;

--- a/3.1/imports/custom-formatting-values.md
+++ b/3.1/imports/custom-formatting-values.md
@@ -1,0 +1,54 @@
+# Custom Formatting Values
+
+[[toc]]
+
+## Value Binder
+
+By default Laravel Excel uses PhpSpreadsheet's default value binder to intelligently format a cell's value when reading it. You may override this behavior by implementing the `WithCustomValueBinder` concern and the `bindValue` method. Your import class may also extend `DefaultValueBinder` to return the default behavior.
+
+```php
+namespace App\Exports;
+
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use Maatwebsite\Excel\Concerns\ToModel;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
+use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder;
+
+class UsersImport extends DefaultValueBinder implements WithCustomValueBinder, ToModel
+{
+    public function bindValue(Cell $cell, $value)
+    {
+        if (is_numeric($value)) {
+            $cell->setValueExplicit($value, DataType::TYPE_NUMERIC);
+
+            return true;
+        }
+
+        // else return default behavior
+        return parent::bindValue($cell, $value);
+    }
+}
+```
+
+## Available DataTypes
+
+* `PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING`
+* `PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_FORMULA`
+* `PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_NUMERIC`
+* `PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_BOOL`
+* `PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_NULL`
+* `PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_INLINE`
+* `PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_ERROR`
+
+## Default Value Binder
+
+If you want to use one value binder for all your imports, you can configure the default value binder in the config.
+
+In `config/excel.php`:
+
+```php
+'value_binder' => [
+    'default' => Maatwebsite\Excel\DefaultValueBinder::class,
+],
+```


### PR DESCRIPTION
I just spent the good part of a day to stop Phpspreadsheet to 'intelligently' format a CSV import. 

I had a column with a barcode that it insisted to intelligently format into scientific notation. I couldn't find anything in the documentation under the import section, tried with custom formatting values, but didn't succeed at first and then read a comment about it not using custom formatting when importing.

I then backtracked the code and found that Phpspreadsheet uses the defaultValueBinder on imports also. So I have added this documentation to the import section as well.