### PR TITLE
Add namespace

### DIFF
--- a/3.1/exports/README.md
+++ b/3.1/exports/README.md
@@ -47,10 +47,12 @@ class UsersExport implements FromCollection
 :fire: In your controller you can call this export now:
 
 ```php
+<?php
+
+namespace App\Http\Controllers;
 
 use App\Exports\UsersExport;
 use Maatwebsite\Excel\Facades\Excel;
-use App\Http\Controllers\Controller;
 
 class UsersController extends Controller 
 {


### PR DESCRIPTION
I found the example results in "Class App\Http\Controllers\UsersController does not exist" until the namespace is added (Laravel 5.8).