### PR TITLE
Add Sheets namespace for sheet classes

### DIFF
--- a/3.1/exports/multiple-sheets.md
+++ b/3.1/exports/multiple-sheets.md
@@ -43,7 +43,7 @@ class InvoicesExport implements WithMultipleSheets
 The `InvoicesPerMonthSheet` can implement concerns like `FromQuery`, `FromCollection`, ... 
 
 ```php
-namespace App\Exports;
+namespace App\Exports\Sheets;
 
 use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\WithTitle;


### PR DESCRIPTION
According to the proposed directory structure, sheet classes should be inside `Sheets` directory. I updated the namespace to reflect that.