### PR TITLE
Add note about validation rules that reference other field names

### DIFF
--- a/3.1/imports/validation.md
+++ b/3.1/imports/validation.md
@@ -91,6 +91,17 @@ class UsersImport implements ToModel, WithValidation, WithHeadingRow
 }
 ```
 
+If your validation rules reference other field names, as in the `different`, `lt`, `lte`, `gt`, `gte`, and `same` rules, the field name must be prefixed with `*.` as in the example below, because validation is done in batches.
+
+```php
+public function rules(): array
+{
+    return [
+        'maximum' => 'gte:*.minimum',
+    ];
+}
+```
+
 ## Custom validation messages
 
 By adding `customValidationMessages()` method to your import, you can specify custom messages for each failure.


### PR DESCRIPTION
As discussed in the question issue raised here: https://github.com/Maatwebsite/Laravel-Excel/issues/2556

I ran into an issue with the 'gte' validation rule and it took me a while to figure out that it needed the '*.' prefix on the field name. Per @patrickbrouwers  response, I'm submitting this suggestion as a note in the docs.