### PR TITLE
Note with regards to default file location

### DIFF
--- a/3.1/imports/README.md
+++ b/3.1/imports/README.md
@@ -72,3 +72,5 @@ class UsersController extends Controller
 ```
 
 :page_facing_up: Find the imported users in your database!
+
+:page_facing_up: By default the application will look for files in `/public`


### PR DESCRIPTION
It's not clear from the 5 minute quickstart where the importer will be looking for files by default. An additional note was added to the end of this documentation page to specify `/public`