### PR TITLE
Made the information about styling a bit clearer.

### DIFF
--- a/3.1/exports/column-formatting.md
+++ b/3.1/exports/column-formatting.md
@@ -147,7 +147,7 @@ Can be used together with `ShouldAutoSize`. Only the columns with explicit width
 
 ## Styling
 
-The `WithStyles` concerns allows styling columns, cells and rows. This might be useful when you want to make the heading row bold.
+The `WithStyles` (available after `v3.1.21`) concerns allows styling columns, cells and rows. This might be useful when you want to make the heading row bold.
 
 ```php
 namespace App\Exports;


### PR DESCRIPTION
I spent an hour debugging the "Interface 'Maatwebsite\Excel\Concerns\WithStyles' not found" message. According to the documentation, version ^3.1 must allow me to use `WithStyles` Concern, but my laravel version is not compatible with the latest (v3.1.26 at that moment) version of laravel-excel. I've added the version number that allows the use of this Concern to the documentation, so less people bang their heads :)