### PR TITLE
Update mapping.md

### DIFF
--- a/3.1/exports/mapping.md
+++ b/3.1/exports/mapping.md
@@ -117,13 +117,12 @@ use Maatwebsite\Excel\Concerns\WithHeadings;
 
 class UsersExport implements FromQuery, WithHeadings
 {   
-    public function prepareRows($rows): array
-    {
-        return array_map(function ($user) {
-            $user->name .= ' (prepared)';
-
-            return $user;
-        }, $rows);
-    }
+public function prepareRows($rows)
+{
+    return $rows->transform(function ($user) {
+        $user->name .= ' (prepared)';
+        
+        return $user;
+    });
 }
 ```


### PR DESCRIPTION
Because $rows passed to prepareRows() is a collection, it cannot go through array_map().
Instead of using array_map() use transform()