### PR TITLE
Add column index to formatter

### DIFF
--- a/3.1/imports/heading-row.md
+++ b/3.1/imports/heading-row.md
@@ -91,8 +91,11 @@ public function model(array $row)
 You can define a custom formatter with `::extend()` in a service provider.
 
 ```php
-HeadingRowFormatter::extend('custom', function($value) {
+HeadingRowFormatter::extend('custom', function($value, $key) {
     return 'do-something-custom' . $value; 
+    
+    // And you can use heading column index.
+    // return 'column-' . $key; 
 });
 ```
 


### PR DESCRIPTION
Request about Custom heading row formatter can use column index. (#3166)