### PR TITLE
docs(export): add WithChunkReading

### DIFF
--- a/3.1/exports/concerns.md
+++ b/3.1/exports/concerns.md
@@ -25,6 +25,7 @@ pageClass: no-toc
 |`Maatwebsite\Excel\Concerns\WithDrawings`| Allows to run one or multiple PhpSpreadsheet (Base)Drawing instances. | [Drawings](/3.1/exports/drawings.html) |
 |`Maatwebsite\Excel\Concerns\WithCustomStartCell`| Allows to specify a custom start cell. Do note that this is only supported for FromCollection exports. | [Custom start cell](/3.1/exports/collection.html#custom-start-cell) |
 |`Maatwebsite\Excel\Concerns\WithPreCalculateFormulas`| Forces PhpSpreadsheet to recalculate all formulae in a workbook when saving, so that the pre-calculated values are immediately available to MS Excel or other office spreadsheet viewer when opening the file. | |
+|`Maatwebsite\Excel\Concerns\WithChunkReading`| Read the sheet in chunks. | |
 
 ### Traits
 


### PR DESCRIPTION
`fromQuery` uses chunking by default, so concerns should included `WithChunkReading`. 