### PR TITLE
Create the headings page

### DIFF
--- a/.vuepress/3.1.js
+++ b/.vuepress/3.1.js
@@ -35,6 +35,7 @@ module.exports = [
             'queued',
             'multiple-sheets',
             'mapping',
+            'headings',
             'column-formatting',
             'settings',
             'drawings',

--- a/3.1/exports/headings.md
+++ b/3.1/exports/headings.md
@@ -1,0 +1,46 @@
+# Headings
+
+[[toc]]
+
+## Adding a heading row
+
+A heading row can easily be added by adding the `WithHeadings` concern. The heading row will be added
+as very first row of the sheet.
+
+```php
+
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+
+class InvoicesExport implements FromQuery, WithHeadings
+{
+    public function headings(): array
+    {
+        return [
+            '#',
+            'User',
+            'Date',
+        ];
+    }
+}
+```
+
+If you need to have multiple heading rows, you can return multiple rows from the `headings()` method:
+
+
+```php
+
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+
+class InvoicesExport implements FromQuery, WithHeadings
+{
+    public function headings(): array
+    {
+        return [
+           ['First row', 'First row'],
+           ['Second row', 'Second row'],
+        ];
+    }
+}
+```

--- a/3.1/exports/mapping.md
+++ b/3.1/exports/mapping.md
@@ -65,49 +65,6 @@ class InvoicesExport implements FromQuery, WithMapping
 }
 ```
 
-## Adding a heading row
-
-A heading row can easily be added by adding the `WithHeadings` concern. The heading row will be added
-as very first row of the sheet.
-
-```php
-
-use Maatwebsite\Excel\Concerns\FromQuery;
-use Maatwebsite\Excel\Concerns\WithHeadings;
-
-class InvoicesExport implements FromQuery, WithHeadings
-{   
-    public function headings(): array
-    {
-        return [
-            '#',
-            'User',
-            'Date',
-        ];
-    }
-}
-```
-
-If you need to have multiple heading rows, you can return multiple rows from the `headings()` method:
-
-
-```php
-
-use Maatwebsite\Excel\Concerns\FromQuery;
-use Maatwebsite\Excel\Concerns\WithHeadings;
-
-class InvoicesExport implements FromQuery, WithHeadings
-{   
-    public function headings(): array
-    {
-        return [
-           ['First row', 'First row'],
-           ['Second row', 'Second row'],
-        ];
-    }
-}
-```
-
 ## Prepare rows
 
 If you need to prepare rows before appending these rows to sheet, you can add method `prepareRows` to your export class. This method will be called before flattening the query output and calling `map()`.


### PR DESCRIPTION
I have never created any spreadsheet without headings. I have never seen spreadsheets without headings either. Headings are crucial.

And it took me quite a bit of time to figure out how to add headings from the docs. I finally found that section in the `Mapping data` page.

I want to create a new page just for adding headings for exporting, like we already have a similar page for importing.