### PR TITLE
Update 4.x docs to reflect latest Laravel-Excel changes

### DIFF
--- a/.vuepress/4.x.js
+++ b/.vuepress/4.x.js
@@ -28,6 +28,7 @@ module.exports = [
             'exporting',
             'data',
             'columns',
+            'template',
             'presentation',
             'performance',
             'settings',

--- a/3.1/getting-started/support.md
+++ b/3.1/getting-started/support.md
@@ -12,11 +12,11 @@ If you use the software commercially and need elaborate support or need it urgen
 
 Versions will be supported for a limited amount of time.
 
-| Version | Laravel Version | Php Version | Support |
-|---- |----|----|----|
-| 2.1 | <=5.6 | <=7.0 | Unsupported since 15-5-2018 |
-| 3.0 | ^5.5 |  ^7.0 | Unsupported since 31-12-2018 |
-| 3.1 | ^5.8\|^6.0\|^7.0\|^8.0\|^9.0\|^10.0 |  ^7.2\|^8.0 | New features |
+| Version | Laravel Version                     | Php Version | Support                      |
+|---------|-------------------------------------|-------------|------------------------------|
+| 2.1     | <=5.6                               | <=7.0       | Unsupported since 15-5-2018  |
+| 3.0     | ^5.5                                | ^7.0        | Unsupported since 31-12-2018 |
+| 3.1     | ^5.8\|^6.0\|^7.0\|^8.0\|^9.0\|^10.0 | ^7.2\|^8.0  | No active support, CVE only  |
 
 ::: warning PHP version support
 Support for PHP versions will only be maintained for a period of six months beyond the end-of-life of that PHP version.

--- a/4.x/exports/columns.md
+++ b/4.x/exports/columns.md
@@ -410,3 +410,85 @@ Text::make('Name')->writing(function(Cell $cell) {
     $cell->getHyperlink()->setUrl('https://spartner.software');
 });
 ```
+
+## Importing with columns
+
+`WithColumns` also works on the import side. Each column's type handles casting the raw cell value to the correct PHP type when a row is read.
+
+### Basic import
+
+Add `WithColumns` to your import class. The `columns()` return value describes which columns to read and how to cast them:
+
+```php
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithColumns;
+use Maatwebsite\Excel\Columns\Date;
+use Maatwebsite\Excel\Columns\Number;
+use Maatwebsite\Excel\Columns\Text;
+
+class UsersImport implements ToModel, WithColumns
+{
+    use Importable;
+
+    public function model(array $row): User
+    {
+        return new User([
+            'name'  => $row['name'],
+            'email' => $row['email'],
+            'dob'   => $row['date_of_birth'], // cast to Carbon
+        ]);
+    }
+
+    public function columns(): array
+    {
+        return [
+            Text::make('name'),
+            Text::make('email'),
+            Date::make('Date of Birth', 'date_of_birth'),
+            Number::make('id'),
+        ];
+    }
+}
+```
+
+The row array keys are derived from the column's attribute (second argument) or, when omitted, from the title converted to snake_case.
+
+### Transforming values on read
+
+Pass a callback as the second argument to transform the raw value after casting:
+
+```php
+Text::make('name', fn (string $name): string => strtolower($name)),
+```
+
+### Heading-aware imports
+
+When combined with `WithHeadingRow`, the column `title` is matched against the heading row. Columns that do not match a heading are skipped:
+
+```php
+class UsersImport implements ToModel, WithColumns, WithHeadingRow
+{
+    use Importable;
+
+    public function model(array $row): User
+    {
+        return new User([
+            'name'  => $row['name'],
+            'email' => $row['email'],
+        ]);
+    }
+
+    public function columns(): array
+    {
+        return [
+            Text::make('Name', 'name'),
+            Text::make('Email', 'email'),
+        ];
+    }
+}
+```
+
+### Conflict guards
+
+`WithColumns` cannot be combined with `WithMappedCells`, `WithColumnLimit`, or `WithGroupedHeadingRow` on the import side, as these concerns describe the same thing. A `ConcernConflictException` is thrown if they are combined.

--- a/4.x/exports/concern-overview.md
+++ b/4.x/exports/concern-overview.md
@@ -13,7 +13,7 @@
 |`Maatwebsite\Excel\Concerns\ShouldAutoSize`| Auto-size the columns in the worksheet. | [Presentation](/4.x/exports/presentation.html) |
 |`Maatwebsite\Excel\Concerns\WithCharts`| Allows running one or multiple PhpSpreadsheet Chart instances. | |
 |`Maatwebsite\Excel\Concerns\WithColumnFormatting`| Format certain columns. | |
-|`Maatwebsite\Excel\Concerns\WithColumns`| Define columns for the export. | |
+|`Maatwebsite\Excel\Concerns\WithColumns`| Define typed columns for exports and imports. | [Columns](/4.x/exports/columns.html) |
 |`Maatwebsite\Excel\Concerns\WithColumnWidths`| Set column widths. | [Presentation](/4.x/exports/presentation.html) |
 |`Maatwebsite\Excel\Concerns\WithCustomChunkSize`| Allows Exportables to define their chunk size. | |
 |`Maatwebsite\Excel\Concerns\WithCustomCsvSettings`| Allows running custom CSV settings for this specific exportable. | [Settings](/4.x/exports/settings.html) |
@@ -29,7 +29,9 @@
 |`Maatwebsite\Excel\Concerns\WithProperties`| Allows setting document properties. | [Settings](/4.x/exports/settings.html) |
 |`Maatwebsite\Excel\Concerns\WithStrictNullComparison`| Uses strict comparisons when testing cells for null values. | [Data sources](/4.x/exports/data.html) |
 |`Maatwebsite\Excel\Concerns\WithStyles`| Allows setting styles on worksheets. | [Presentation](/4.x/exports/presentation.html) |
+|`Maatwebsite\Excel\Concerns\WithExportTemplate`| Base an export on an existing spreadsheet file, preserving its styles, formulas and extra sheets. | [Export Templates](/4.x/exports/template.html) |
 |`Maatwebsite\Excel\Concerns\WithTitle`| Set the Workbook or Worksheet title. | |
+|`Maatwebsite\Excel\Concerns\ShouldBatch`| Dispatch queued exports or chunked imports as a job batch instead of a chain. | [Performance](/4.x/exports/performance.html) |
 
 ### Traits
 

--- a/4.x/exports/data.md
+++ b/4.x/exports/data.md
@@ -244,7 +244,7 @@ class ProductsExport implements FromScout
 {
     use Exportable;
 
-    public function query(): \Laravel\Scout\Builder
+    public function scout(): \Laravel\Scout\Builder
     {
         return Product::search('*');
     }
@@ -254,6 +254,67 @@ class ProductsExport implements FromScout
 :::tip
 `FromScout` requires `laravel/scout` to be installed.
 :::
+
+## Custom source handlers
+
+If none of the built-in data source concerns fit your use case, you can register a custom source handler. This lets you teach Laravel Excel how to handle any custom export source without forking the library.
+
+### Implementing a handler
+
+Create a class that implements `SheetSourceHandler` (for synchronous exports), `QueuedSheetSourceHandler` (for queued exports), or both:
+
+```php
+use Maatwebsite\Excel\Concerns\Export;
+use Maatwebsite\Excel\Contracts\SheetSourceHandler;
+use Maatwebsite\Excel\Sheet;
+
+class ApiSourceHandler implements SheetSourceHandler
+{
+    public function canHandle(Export $sheetExport): bool
+    {
+        return $sheetExport instanceof FromApi;
+    }
+
+    public function handle(Sheet $sheet, Export $sheetExport): void
+    {
+        foreach ($sheetExport->fetch() as $row) {
+            $sheet->append([$row]);
+        }
+    }
+}
+```
+
+### Registering a handler
+
+Handlers can be registered in a service provider using the `Excel::registerSourceHandler()` method. User-registered handlers always take priority over built-in ones.
+
+```php
+use Maatwebsite\Excel\Facades\Excel;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Excel::registerSourceHandler(new ApiSourceHandler);
+
+        // Or register by class name (resolved lazily from the container):
+        Excel::registerSourceHandler(ApiSourceHandler::class);
+
+        // Multiple handlers at once:
+        Excel::registerSourceHandler(ApiSourceHandler::class, AnotherHandler::class);
+    }
+}
+```
+
+You can also list handler class names in `config/excel.php` under `exports.source_handlers`:
+
+```php
+'exports' => [
+    'source_handlers' => [
+        App\Exports\Handlers\ApiSourceHandler::class,
+    ],
+],
+```
 
 ## Generic data manipulations
 

--- a/4.x/exports/performance.md
+++ b/4.x/exports/performance.md
@@ -59,22 +59,58 @@ public function collection(): LazyCollection
 
 ## Queuing
 
-When the data set is too big for the user to wait sync, u can queue it.
+When the data set is too big for the user to wait sync, you can queue it.
 
 ```php
 class ExportUsers implements ShouldQueue
 {
-    use Queuable;
+    use Queueable;
 
     public $queue = 'long-running';
     public $timeout = 900;
 
-    public function handle()
+    public function handle(): void
     {
         Excel::store(new UsersExport, 'users.xlsx');
     }
 }
 ```
+
+## Job batching
+
+Queued exports (and chunked queued imports) can be dispatched as a [Laravel job batch](https://laravel.com/docs/queues#job-batching) instead of a chain by implementing the `ShouldBatch` marker interface.
+
+```php
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\ShouldBatch;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class UsersExport implements FromQuery, ShouldQueue, ShouldBatch
+{
+    use Exportable;
+
+    public function query(): Builder
+    {
+        return User::query();
+    }
+}
+```
+
+When `ShouldBatch` is implemented, `queue()` and `store()` return a `PendingBatch` instead of a `PendingDispatch`, so you can attach batch callbacks:
+
+```php
+$batch = (new UsersExport)->queue('users.xlsx')
+    ->name('Users export')
+    ->then(fn () => // batch succeeded)
+    ->catch(fn () => // at least one job failed);
+
+$batch->dispatch();
+```
+
+:::tip
+`ShouldBatch` requires `WithMultipleSheets` or `WithChunkReading` to have more than one job in the batch. A single-sheet export without chunk reading will still return a `PendingBatch`, but it will contain only one job.
+:::
 
 ## Cell caching
 

--- a/4.x/exports/template.md
+++ b/4.x/exports/template.md
@@ -1,0 +1,103 @@
+# Export Templates
+
+[[toc]]
+
+## Introduction
+
+The `WithExportTemplate` concern lets you base an export on an existing spreadsheet file. Instead of starting from a blank workbook, Laravel Excel loads the template file and writes your data into it — preserving existing styles, formulas, page setup, additional sheets, and any other content defined in the template.
+
+## Basic usage
+
+Implement `WithExportTemplate` and return the absolute path to the template file from `exportTemplate()`:
+
+```php
+namespace App\Exports;
+
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithCustomStartCell;
+use Maatwebsite\Excel\Concerns\WithExportTemplate;
+
+class ReportExport implements FromArray, WithCustomStartCell, WithExportTemplate
+{
+    use Exportable;
+
+    public function array(): array
+    {
+        return [
+            ['Patrick', 'Brouwers'],
+            ['Taylor', 'Otwell'],
+        ];
+    }
+
+    public function startCell(): string
+    {
+        return 'A3';
+    }
+
+    public function exportTemplate(): string
+    {
+        return storage_path('templates/report.xlsx');
+    }
+}
+```
+
+In this example the template already has a title in `A1`, a formula in `C3` and landscape page orientation. Those are preserved in the output; only rows from `A3` downward are written by the export.
+
+## What is preserved
+
+Everything in the template file is kept unless your export explicitly overwrites it:
+
+- **Styles and formatting** — fonts, borders, fills, number formats
+- **Formulas** — cells with formulas remain intact
+- **Page setup** — orientation, margins, print area
+- **Additional sheets** — extra worksheets in the template are carried over to the output
+
+## Combining with `WithMultipleSheets`
+
+When your export uses `WithMultipleSheets`, each sheet in the export is written into the corresponding worksheet in the template (by position). Any template worksheets beyond the number of export sheets are preserved as-is.
+
+```php
+class MultiSheetReportExport implements WithMultipleSheets, WithExportTemplate
+{
+    use Exportable;
+
+    public function sheets(): array
+    {
+        return [
+            new DataSheet,
+            new SummarySheet,
+        ];
+    }
+
+    public function exportTemplate(): string
+    {
+        return storage_path('templates/multi-sheet-report.xlsx');
+    }
+}
+```
+
+## Queued exports
+
+`WithExportTemplate` works with queued exports. The template path is resolved when the first chunk job runs.
+
+```php
+class QueuedReportExport implements FromQuery, ShouldQueue, WithExportTemplate
+{
+    use Exportable, Queueable;
+
+    public function query(): Builder
+    {
+        return Report::query();
+    }
+
+    public function exportTemplate(): string
+    {
+        return storage_path('templates/report.xlsx');
+    }
+}
+```
+
+:::warning
+Make sure the template file exists and is readable when the job runs. If you store templates on a remote disk, copy them to local storage first or use an absolute local path.
+:::

--- a/4.x/getting-started/support.md
+++ b/4.x/getting-started/support.md
@@ -15,7 +15,7 @@ Versions will be supported for a limited amount of time.
 | Version | Laravel Version | Php Version | Support                      |
 |---------|-----------------|-------------|------------------------------|
 | 4.0     | ^12\|^13        | ^8.3        | New features                 |
-| 3.1     | >=5.8 \| <=13.x | ^7.2\|^8.0  | Support till ...             |
+| 3.1     | >=5.8 \| <=13.x | ^7.2\|^8.0  | No active support, CVE only  |
 | 3.0     | ^5.5            | ^7.0        | Unsupported since 31-12-2018 |
 | 2.1     | <=5.6           | <=7.0       | Unsupported since 15-5-2018  |
 

--- a/4.x/getting-started/upgrade.md
+++ b/4.x/getting-started/upgrade.md
@@ -11,6 +11,17 @@ You will also need **phpoffice/phpspreadsheet 5.3** or higher.
 
 If you are on an older version of PHP or Laravel, upgrade those first before upgrading to Laravel-Excel 4.0.
 
+### PhpSpreadsheet 5
+
+The underlying `phpoffice/phpspreadsheet` dependency has been upgraded from `^1.30` to `^5.3`. Code that only uses Laravel-Excel's own API (exports, imports, concerns) is largely unaffected. However, if you interact with PhpSpreadsheet objects directly, review your code against the PhpSpreadsheet 2.x–5.x breaking changes. Common places this applies:
+
+- Event listeners registered via `WithEvents` (e.g. styling a sheet through `$event->sheet->getDelegate()` in `AfterSheet`)
+- The `WithCharts` and `WithDrawings` concerns
+- Custom value binders (`WithCustomValueBinder`) and anything extending `DefaultValueBinder`
+- Direct use of PhpSpreadsheet classes such as `NumberFormat`, `Style`, or `Coordinate`
+
+See the [PhpSpreadsheet changelog](https://github.com/PHPOffice/PhpSpreadsheet/blob/master/CHANGELOG.md) for the 2.0, 3.0, 4.0 and 5.0 breaking changes.
+
 ### Fully typed codebase
 
 Native PHP types have been added across the entire codebase, including all public methods and interfaces. If you implement any Laravel-Excel interface or override any method, you must update your method signatures to include the matching return types.
@@ -48,9 +59,14 @@ Common return types to add:
 | `map($row)`         | `array`        |
 | `model(array $row)` | `?Model`       |
 | `batchSize()`       | `int`          |
-| `uniqueBy()`        | `string|array` |
+| `uniqueBy()`        | `string\|array` |
 | `rules()`           | `array`        |
 | `registerEvents()`  | `array`        |
+
+Because return types are now enforced natively, some signatures are stricter than the 3.1 docblocks suggested:
+
+- `Exportable::store()` returns `bool|PendingDispatch|PendingBatch`; `Exportable::queue()` returns `PendingDispatch|PendingBatch`.
+- `Importable::import()` returns `Importer|PendingDispatch|PendingBatch`; `Importable::queue()` returns `PendingDispatch|PendingBatch` (it no longer advertises returning the importable instance itself).
 
 ### FromScout
 
@@ -80,20 +96,80 @@ class ProductsExport implements FromScout
 }
 ```
 
+### Export and Import marker interfaces
+
+Two new marker interfaces have been introduced: `Maatwebsite\Excel\Concerns\Export` and `Maatwebsite\Excel\Concerns\Import`. All export-related data-source concerns (e.g. `FromArray`, `FromCollection`, `FromQuery`) now extend `Export`, and all import data-sink concerns (e.g. `ToModel`, `ToArray`, `ToCollection`, `OnEachRow`) now extend `Import`.
+
+Because your export and import classes already implement those concerns, they automatically satisfy the new interfaces — no changes are required in most cases.
+
+You can now use `Export` and `Import` as type hints wherever you previously used `object`:
+
+```php
+use Maatwebsite\Excel\Concerns\Export;
+
+public function handle(Export $export): void { ... }
+```
+
+**`WithMultipleSheets`** — the `sheets()` method docblock return type has been narrowed from `array<int|string, object>` to `array<int|string, Export|Import>`. Sheets returned should implement at least one export or import concern, which is almost certainly already the case.
+
+**`Event::getConcernable()`** now returns `Export|Import|null` instead of `object`. Update any code that relies on the `object` return type in a type-strict context.
+
+### Job batching (`ShouldBatch`)
+
+Queued exports and chunked queued imports can now implement the `Maatwebsite\Excel\Concerns\ShouldBatch` marker interface to be dispatched as a [job batch](https://laravel.com/docs/queues#job-batching) instead of a chain.
+
+```php
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\ShouldBatch;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class UsersExport implements FromQuery, ShouldQueue, ShouldBatch
+{
+    use Exportable;
+
+    public function query(): Builder
+    {
+        return User::query();
+    }
+}
+```
+
+When `ShouldBatch` is implemented, `Excel::store()`, `Excel::queue()`, `Exportable::queue()` and `Importable::queue()` return an `Illuminate\Bus\PendingBatch` instead of a `PendingDispatch`. Update any code that type-hints these return values.
+
 ### Queue attributes
 
-Imports now support `#[Queue]` and `#[Connection]` PHP attributes as an alternative to implementing the queue configuration methods.
+Imports support Laravel's native `#[Queue]` and `#[Connection]` PHP attributes (requires Laravel 13+) in addition to the existing `$queue` and `$connection` properties.
+
+```php
+use Illuminate\Queue\Attributes\Connection;
+use Illuminate\Queue\Attributes\Queue;
+
+#[Queue('imports')]
+#[Connection('redis')]
+class UsersImport implements ToModel, WithChunkReading, ShouldQueue
+{
+    // ...
+}
+```
+
+### Configuration
+
+The published configuration file (`config/excel.php`) has no key changes compared to 3.1 — there is no need to republish or migrate your configuration.
+
+### Removed requirements
+
+The `ext-json` requirement has been dropped (JSON support is bundled with PHP 8). No action is required.
 
 __Additions__
 
-* Column exports
-* Column imports
+* Column exports and imports (`WithColumns`)
 * `FromScout` concern for Scout-based exports
-* Queue attribute support (`#[Queue]`, `#[Connection]`)
-
-__Deprecations__
-
-* Queued exports are deprecated and will be removed in 5.x. Please check the [performance documentation](/4.x/exports/performance.html) for the new and improved way.
+* `WithExportTemplate` concern to base exports on an existing spreadsheet
+* `ShouldBatch` marker interface for job-batch queuing
+* Queue attribute support (`#[Queue]`, `#[Connection]`) on imports
+* `Export` and `Import` marker interfaces
+* Extensible export source handler registry (`Excel::registerSourceHandler()`)
 
 ## Upgrading to 3.1 from 3.0
 

--- a/4.x/imports/queued.md
+++ b/4.x/imports/queued.md
@@ -95,6 +95,74 @@ class UsersImport implements ToModel, WithChunkReading, ShouldQueue, WithEvents
 }
 ```
 
+## Job batching
+
+Chunked queued imports can be dispatched as a [Laravel job batch](https://laravel.com/docs/queues#job-batching) instead of a chain by implementing the `ShouldBatch` marker interface alongside `ShouldQueue` and `WithChunkReading`.
+
+```php
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
+use Maatwebsite\Excel\Concerns\ShouldBatch;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class UsersImport implements ToModel, WithChunkReading, ShouldQueue, ShouldBatch
+{
+    use Importable;
+
+    public function model(array $row): User|null
+    {
+        return new User(['name' => $row[0]]);
+    }
+
+    public function chunkSize(): int
+    {
+        return 1000;
+    }
+}
+```
+
+When `ShouldBatch` is implemented, `queue()` and `import()` return an `Illuminate\Bus\PendingBatch`:
+
+```php
+$batch = (new UsersImport)->queue('users.xlsx')
+    ->name('Users import')
+    ->then(fn () => // all chunks succeeded)
+    ->catch(fn () => // at least one chunk failed);
+
+$batch->dispatch();
+```
+
+## Queue attributes
+
+In addition to the `$queue` and `$connection` properties, imports support Laravel's native `#[Queue]` and `#[Connection]` PHP attributes (requires Laravel 13+):
+
+```php
+use Illuminate\Queue\Attributes\Connection;
+use Illuminate\Queue\Attributes\Queue;
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+#[Queue('imports')]
+#[Connection('redis')]
+class UsersImport implements ToModel, WithChunkReading, ShouldQueue
+{
+    use Importable;
+
+    public function model(array $row): User|null
+    {
+        return new User(['name' => $row[0]]);
+    }
+
+    public function chunkSize(): int
+    {
+        return 1000;
+    }
+}
+```
+
 ## Appending jobs
 
 When queuing an import an instance of Laravel's `PendingDispatch` is returned. This means you can chain extra jobs that will be added to the end of the queue and only executed if all import jobs are correctly executed.


### PR DESCRIPTION
## Summary

- Fix `FromScout` method name (`query()` → `scout()`)
- Add import support section to `columns.md`
- Add `WithExportTemplate` documentation (new page, sidebar entry, concern overview)
- Add `ShouldBatch` documentation for exports and queued imports
- Add `#[Queue]` / `#[Connection]` attribute example to queued imports
- Add custom export source handler registry (`Excel::registerSourceHandler()`)
- Expand 4.0 upgrade guide: PhpSpreadsheet 5 breaking changes, stricter typed signatures, `Export`/`Import` interfaces, `ShouldBatch`, queue attributes, dropped `ext-json` requirement
-